### PR TITLE
Clarify one of the guarantees in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ func SecureJoin(root, unsafePath string) (string, error)
 This library **guarantees** the following:
 
 * If no error is set, the resulting string **must** be a child path of
-  `SecureJoin` and will not contain any symlink path components (they will all
+  `root` and will not contain any symlink path components (they will all
   be expanded).
 
 * When expanding symlinks, all symlink path components **must** be resolved


### PR DESCRIPTION
I believe there is an error, the resulting string is a child of `root`, not `SecureJoin`.