### PR TITLE
tests: make sure the directory handle is kept alive in rename loop

### DIFF
--- a/util_linux_test.go
+++ b/util_linux_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -111,6 +112,8 @@ func doRenameExchangeLoop(pauseCh chan struct{}, exitCh <-chan struct{}, dir *os
 					// enter a bad filesystem state if we get paused.
 					panic(fmt.Sprintf("renameat2([%d]%q, %q, ..., %q, RENAME_EXCHANGE) = %v", int(dir.Fd()), dir.Name(), pathA, pathB, err))
 				}
+				// Make sure GC doesn't close the directory handle.
+				runtime.KeepAlive(dir)
 			}
 		}
 	}


### PR DESCRIPTION
It turns out the GC can close the directory during our loop in CI sometimes, leading to the following failures (note that dir.Fd() returns -1, which is a closed directory):

```
  === RUN   TestPartialLookup_RacingRename/openat2=true/swap-dir-danglinglink-basic
  panic: renameat2([-1]"/tmp/TestPartialLookup_RacingRenameopenat2=trueswap-dir-file-basic3291115487/001/tree", "a/b", ..., "file", RENAME_EXCHANGE) = no such file or directory

  goroutine 552 [running]:
  github.com/cyphar/filepath-securejoin.doRenameExchangeLoop(0xc000027680, 0xc0000276e0, 0xc0000025a8, {0x66c786, 0x3}, {0x66c8f4, 0x4})
      /home/runner/work/filepath-securejoin/filepath-securejoin/util_linux_test.go:111 +0x38c
  created by github.com/cyphar/filepath-securejoin.TestPartialLookup_RacingRename.func1.1 in goroutine 551
      /home/runner/work/filepath-securejoin/filepath-securejoin/lookup_linux_test.go:561 +0x525
  exit status 2
```

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>