### PR TITLE
Fix compilation on 32bit architectures such as i386, armhf

### DIFF
--- a/mkdir_linux.go
+++ b/mkdir_linux.go
@@ -22,6 +22,8 @@ var (
 	errPossibleAttack = errors.New("possible attack detected")
 )
 
+type FileMode = os.FileMode
+
 // MkdirAllHandle is equivalent to [MkdirAll], except that it is safer to use
 // in two respects:
 //
@@ -40,7 +42,7 @@ var (
 // a brand new lookup of unsafePath (such as with [SecureJoin] or openat2) after
 // doing [MkdirAll]. If you intend to open the directory after creating it, you
 // should use MkdirAllHandle.
-func MkdirAllHandle(root *os.File, unsafePath string, mode int) (_ *os.File, Err error) {
+func MkdirAllHandle(root *os.File, unsafePath string, mode FileMode) (_ *os.File, Err error) {
 	// Make sure there are no os.FileMode bits set.
 	if mode&^0o7777 != 0 {
 		return nil, fmt.Errorf("%w for mkdir 0o%.3o", errInvalidMode, mode)
@@ -191,7 +193,7 @@ func MkdirAllHandle(root *os.File, unsafePath string, mode int) (_ *os.File, Err
 //
 // NOTE: The mode argument must be set the unix mode bits (unix.S_I...), not
 // the Go generic mode bits ([os.FileMode]...).
-func MkdirAll(root, unsafePath string, mode int) error {
+func MkdirAll(root, unsafePath string, mode FileMode) error {
 	rootDir, err := os.OpenFile(root, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return err


### PR DESCRIPTION
On those architectures, the tests fail to build with an overflow error:

   src/github.com/cyphar/filepath-securejoin/mkdir_linux_test.go:254:8: constant 2147484159 overflows int FAIL	 
   github.com/cyphar/filepath-securejoin [build failed]

Turns out that FileMode is defined as an uint32 in the os.fs package. Since `MkdirAll` is intended as a replacement for os.MkdirAll, it makes sense to use the same types for all arguments, and that means os.FileMode for the mode parameter.