### PR TITLE
go: lower Go requirement to Go 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
+          - "1.18"
+          - "1.20"
           - "1.21"
           - "1.22"
           - "^1"
@@ -26,6 +28,8 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: mkdir gocoverdir
+        # We can only use -test.gocoverdir for Go >= 1.20.
+        if: ${{ matrix.go-version != '1.18' && matrix.go-version != '1.19' }}
         run: |
           # mktemp --tmpdir -d gocoverdir.XXXXXXXX
           function New-TemporaryDirectory {
@@ -42,8 +46,15 @@ jobs:
           $GOCOVERDIR = (New-TemporaryDirectory -Prefix "gocoverdir")
           echo "GOCOVERDIR=$GOCOVERDIR" >>"$env:GITHUB_ENV"
       - name: unit tests
-        run: go test -v -cover '-test.gocoverdir' "$env:GOCOVERDIR" ./...
+        run: |
+          if (Test-Path 'env:GOCOVERDIR') {
+            go test -v -cover '-test.gocoverdir' "$env:GOCOVERDIR" ./...
+          } else {
+            go test -v ./...
+          }
       - name: upload coverage
+        # We can only use -test.gocoverdir for Go >= 1.20.
+        if: ${{ matrix.go-version != '1.18' && matrix.go-version != '1.19' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ runner.os }}-${{ github.job }}-${{ strategy.job-index }}
@@ -57,6 +68,8 @@ jobs:
           - ubuntu-latest
           - macos-latest
         go-version:
+          - "1.18"
+          - "1.20"
           - "1.21"
           - "1.22"
           - "^1"
@@ -67,14 +80,18 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: mkdir gocoverdir
+        # We can only use -test.gocoverdir for Go >= 1.20.
+        if: ${{ matrix.go-version != '1.18' && matrix.go-version != '1.19' }}
         run: |
           GOCOVERDIR="$(mktemp --tmpdir -d gocoverdir.XXXXXXXX)"
           echo "GOCOVERDIR=$GOCOVERDIR" >>"$GITHUB_ENV"
       - name: go test
-        run: go test -v -cover -timeout=30m -test.gocoverdir="$GOCOVERDIR" ./...
+        run: go test -v -timeout=30m ${GOCOVERDIR:+-cover -test.gocoverdir="$GOCOVERDIR"} ./...
       - name: sudo go test
-        run: sudo go test -v -cover -timeout=30m -test.gocoverdir="$GOCOVERDIR" ./...
+        run: sudo go test -v -timeout=30m ${GOCOVERDIR:+-cover -test.gocoverdir="$GOCOVERDIR"} ./...
       - name: upload coverage
+        # We can only use -test.gocoverdir for Go >= 1.20.
+        if: ${{ matrix.go-version != '1.18' && matrix.go-version != '1.19' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ runner.os }}-${{ github.job }}-${{ strategy.job-index }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
           - "1.18"
           - "1.20"
           - "1.21"
-          - "1.22"
-          - "^1"
+          - "oldstable"
+          - "stable"
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -98,8 +98,8 @@ jobs:
           - "1.18"
           - "1.20"
           - "1.21"
-          - "1.22"
-          - "^1"
+          - "oldstable"
+          - "stable"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "^1"
+          go-version: "stable"
       - name: download all coverage
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,33 @@ on:
     - cron: "30 10 * * 0"
 
 jobs:
+  test-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+        go-version:
+          - "1.18"
+          - "1.19"
+          - "1.20"
+          - "1.21"
+          - "1.22"
+          - "1.23"
+          - "^1"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: go build check
+        run: go build ./...
+      - name: go test build check
+        run: go test -run none ./...
+
   test-windows:
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
 
+### Compatibility ###
+- The minimum Go version requirement for `filepath-securejoin` is now Go 1.18
+  (we use generics internally).
+
+  For reference, `filepath-securejoin@v0.3.0` somewhat-arbitrarily bumped the
+  Go version requirement to 1.21.
+
+  While we did make some use of Go 1.21 stdlib features (and in principle Go
+  versions <= 1.21 are no longer even supported by upstream anymore), some
+  downstreams have complained that the version bump has meant that they have to
+  do workarounds when backporting fixes that use the new `filepath-securejoin`
+  API onto old branches. This is not an ideal situation, but since using this
+  library is probably better for most downstreams than a hand-rolled
+  workaround, we now have compatibility shims that allow us to build on older
+  Go versions.
+
 ## [0.3.5] - 2024-12-06 ##
+
 ### Fixed ###
 - `MkdirAll` will now no longer return an `EEXIST` error if two racing
   processes are creating the same directory. We will still verify that the path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   library is probably better for most downstreams than a hand-rolled
   workaround, we now have compatibility shims that allow us to build on older
   Go versions.
+- Lower minimum version requirement for `golang.org/x/sys` to `v0.18.0` (we
+  need the wrappers for `fsconfig(2)`), which should also make backporting
+  patches to older branches easier.
 
 ## [0.3.5] - 2024-12-06 ##
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cyphar/filepath-securejoin
 
-go 1.21
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/sys v0.28.0
+	golang.org/x/sys v0.18.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/gocompat_errors_go120.go
+++ b/gocompat_errors_go120.go
@@ -1,0 +1,18 @@
+//go:build linux && go1.20
+
+// Copyright (C) 2024 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package securejoin
+
+import (
+	"fmt"
+)
+
+// wrapBaseError is a helper that is equivalent to fmt.Errorf("%w: %w"), except
+// that on pre-1.20 Go versions only errors.Is() works properly (errors.Unwrap)
+// is only guaranteed to give you baseErr.
+func wrapBaseError(baseErr, extraErr error) error {
+	return fmt.Errorf("%w: %w", extraErr, baseErr)
+}

--- a/gocompat_errors_test.go
+++ b/gocompat_errors_test.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+// Copyright (C) 2024 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package securejoin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoCompatErrorWrap(t *testing.T) {
+	baseErr := errors.New("base error")
+	extraErr := errors.New("extra error")
+
+	err := wrapBaseError(baseErr, extraErr)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, baseErr, "wrapped error should contain base error")
+	assert.ErrorIs(t, err, extraErr, "wrapped error should contain extra error")
+}

--- a/gocompat_errors_unsupported.go
+++ b/gocompat_errors_unsupported.go
@@ -1,0 +1,38 @@
+//go:build linux && !go1.20
+
+// Copyright (C) 2024 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package securejoin
+
+import (
+	"fmt"
+)
+
+type wrappedError struct {
+	inner   error
+	isError error
+}
+
+func (err wrappedError) Is(target error) bool {
+	return err.isError == target
+}
+
+func (err wrappedError) Unwrap() error {
+	return err.inner
+}
+
+func (err wrappedError) Error() string {
+	return fmt.Sprintf("%v: %v", err.isError, err.inner)
+}
+
+// wrapBaseError is a helper that is equivalent to fmt.Errorf("%w: %w"), except
+// that on pre-1.20 Go versions only errors.Is() works properly (errors.Unwrap)
+// is only guaranteed to give you baseErr.
+func wrapBaseError(baseErr, extraErr error) error {
+	return wrappedError{
+		inner:   baseErr,
+		isError: extraErr,
+	}
+}

--- a/gocompat_generics_go121.go
+++ b/gocompat_generics_go121.go
@@ -1,0 +1,32 @@
+//go:build linux && go1.21
+
+// Copyright (C) 2024 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package securejoin
+
+import (
+	"slices"
+	"sync"
+)
+
+func slices_DeleteFunc[S ~[]E, E any](slice S, delFn func(E) bool) S {
+	return slices.DeleteFunc(slice, delFn)
+}
+
+func slices_Contains[S ~[]E, E comparable](slice S, val E) bool {
+	return slices.Contains(slice, val)
+}
+
+func slices_Clone[S ~[]E, E any](slice S) S {
+	return slices.Clone(slice)
+}
+
+func sync_OnceValue[T any](f func() T) func() T {
+	return sync.OnceValue(f)
+}
+
+func sync_OnceValues[T1, T2 any](f func() (T1, T2)) func() (T1, T2) {
+	return sync.OnceValues(f)
+}

--- a/gocompat_generics_unsupported.go
+++ b/gocompat_generics_unsupported.go
@@ -1,0 +1,124 @@
+//go:build linux && !go1.21
+
+// Copyright (C) 2024 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package securejoin
+
+import (
+	"sync"
+)
+
+// These are very minimal implementations of functions that appear in Go 1.21's
+// stdlib, included so that we can build on older Go versions. Most are
+// borrowed directly from the stdlib, and a few are modified to be "obviously
+// correct" without needing to copy too many other helpers.
+
+// clearSlice is equivalent to the builtin clear from Go 1.21.
+// Copied from the Go 1.24 stdlib implementation.
+func clearSlice[S ~[]E, E any](slice S) {
+	var zero E
+	for i := range slice {
+		slice[i] = zero
+	}
+}
+
+// Copied from the Go 1.24 stdlib implementation.
+func slices_IndexFunc[S ~[]E, E any](s S, f func(E) bool) int {
+	for i := range s {
+		if f(s[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+// Copied from the Go 1.24 stdlib implementation.
+func slices_DeleteFunc[S ~[]E, E any](s S, del func(E) bool) S {
+	i := slices_IndexFunc(s, del)
+	if i == -1 {
+		return s
+	}
+	// Don't start copying elements until we find one to delete.
+	for j := i + 1; j < len(s); j++ {
+		if v := s[j]; !del(v) {
+			s[i] = v
+			i++
+		}
+	}
+	clearSlice(s[i:]) // zero/nil out the obsolete elements, for GC
+	return s[:i]
+}
+
+// Similar to the stdlib slices.Contains, except that we don't have
+// slices.Index so we need to use slices.IndexFunc for this non-Func helper.
+func slices_Contains[S ~[]E, E comparable](s S, v E) bool {
+	return slices_IndexFunc(s, func(e E) bool { return e == v }) >= 0
+}
+
+// Copied from the Go 1.24 stdlib implementation.
+func slices_Clone[S ~[]E, E any](s S) S {
+	// Preserve nil in case it matters.
+	if s == nil {
+		return nil
+	}
+	return append(S([]E{}), s...)
+}
+
+// Copied from the Go 1.24 stdlib implementation.
+func sync_OnceValue[T any](f func() T) func() T {
+	var (
+		once   sync.Once
+		valid  bool
+		p      any
+		result T
+	)
+	g := func() {
+		defer func() {
+			p = recover()
+			if !valid {
+				panic(p)
+			}
+		}()
+		result = f()
+		f = nil
+		valid = true
+	}
+	return func() T {
+		once.Do(g)
+		if !valid {
+			panic(p)
+		}
+		return result
+	}
+}
+
+// Copied from the Go 1.24 stdlib implementation.
+func sync_OnceValues[T1, T2 any](f func() (T1, T2)) func() (T1, T2) {
+	var (
+		once  sync.Once
+		valid bool
+		p     any
+		r1    T1
+		r2    T2
+	)
+	g := func() {
+		defer func() {
+			p = recover()
+			if !valid {
+				panic(p)
+			}
+		}()
+		r1, r2 = f()
+		f = nil
+		valid = true
+	}
+	return func() (T1, T2) {
+		once.Do(g)
+		if !valid {
+			panic(p)
+		}
+		return r1, r2
+	}
+}

--- a/lookup_linux.go
+++ b/lookup_linux.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -113,7 +112,7 @@ func (s *symlinkStack) push(dir *os.File, remainingPath, linkTarget string) erro
 		return nil
 	}
 	// Split the link target and clean up any "" parts.
-	linkTargetParts := slices.DeleteFunc(
+	linkTargetParts := slices_DeleteFunc(
 		strings.Split(linkTarget, "/"),
 		func(part string) bool { return part == "" || part == "." })
 

--- a/lookup_linux_test.go
+++ b/lookup_linux_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
 
@@ -473,36 +472,36 @@ func TestPartialLookup_RacingRename(t *testing.T) {
 			allowedResults     []lookupResult
 		}{
 			// Swap a symlink in and out.
-			"swap-dir-link1-basic":   {"a/b", "b-link", "a/b/c/d/e", nil, slices.Clone(defaultExpected)},
-			"swap-dir-link2-basic":   {"a/b/c", "c-link", "a/b/c/d/e", nil, slices.Clone(defaultExpected)},
-			"swap-dir-link1-dotdot1": {"a/b", "b-link", "a/b/../b/../b/../b/../b/../b/../b/c/d/../d/../d/../d/../d/../d/e", nil, slices.Clone(defaultExpected)},
-			"swap-dir-link1-dotdot2": {"a/b", "b-link", "a/b/c/../c/../c/../c/../c/../c/../c/d/../d/../d/../d/../d/../d/e", nil, slices.Clone(defaultExpected)},
-			"swap-dir-link2-dotdot":  {"a/b/c", "c-link", "a/b/c/../c/../c/../c/../c/../c/../c/d/../d/../d/../d/../d/../d/e", nil, slices.Clone(defaultExpected)},
+			"swap-dir-link1-basic":   {"a/b", "b-link", "a/b/c/d/e", nil, slices_Clone(defaultExpected)},
+			"swap-dir-link2-basic":   {"a/b/c", "c-link", "a/b/c/d/e", nil, slices_Clone(defaultExpected)},
+			"swap-dir-link1-dotdot1": {"a/b", "b-link", "a/b/../b/../b/../b/../b/../b/../b/c/d/../d/../d/../d/../d/../d/e", nil, slices_Clone(defaultExpected)},
+			"swap-dir-link1-dotdot2": {"a/b", "b-link", "a/b/c/../c/../c/../c/../c/../c/../c/d/../d/../d/../d/../d/../d/e", nil, slices_Clone(defaultExpected)},
+			"swap-dir-link2-dotdot":  {"a/b/c", "c-link", "a/b/c/../c/../c/../c/../c/../c/../c/d/../d/../d/../d/../d/../d/e", nil, slices_Clone(defaultExpected)},
 			// TODO: Swap a directory.
 			// Swap a non-directory.
 			"swap-dir-file-basic": {"a/b", "file", "a/b/c/d/e", []error{unix.ENOTDIR, unix.ENOENT}, append(
 				// We could hit one of the final paths.
-				slices.Clone(defaultExpected),
+				slices_Clone(defaultExpected),
 				// We could hit the file and stop resolving.
 				lookupResult{handlePath: "/file", remainingPath: "c/d/e", fileType: unix.S_IFREG},
 			)},
 			"swap-dir-file-dotdot": {"a/b", "file", "a/b/c/../c/../c/../c/../c/../c/../c/d/../d/../d/../d/../d/../d/e", []error{unix.ENOTDIR, unix.ENOENT}, append(
 				// We could hit one of the final paths.
-				slices.Clone(defaultExpected),
+				slices_Clone(defaultExpected),
 				// We could hit the file and stop resolving.
 				lookupResult{handlePath: "/file", remainingPath: "c/d/e", fileType: unix.S_IFREG},
 			)},
 			// Swap a dangling symlink.
-			"swap-dir-danglinglink-basic":  {"a/b", "bad-link", "a/b/c/d/e", []error{unix.ENOENT}, slices.Clone(defaultExpected)},
-			"swap-dir-danglinglink-dotdot": {"a/b", "bad-link", "a/b/c/../c/../c/../c/../c/../c/../c/d/../d/../d/../d/../d/../d/e", []error{unix.ENOENT}, slices.Clone(defaultExpected)},
+			"swap-dir-danglinglink-basic":  {"a/b", "bad-link", "a/b/c/d/e", []error{unix.ENOENT}, slices_Clone(defaultExpected)},
+			"swap-dir-danglinglink-dotdot": {"a/b", "bad-link", "a/b/c/../c/../c/../c/../c/../c/../c/d/../d/../d/../d/../d/../d/e", []error{unix.ENOENT}, slices_Clone(defaultExpected)},
 			// Swap the root.
-			"swap-root-basic":        {".", "../outsideroot", "a/b/c/d/e", nil, slices.Clone(defaultExpected)},
-			"swap-root-dotdot":       {".", "../outsideroot", "a/b/../../a/b/../../a/b/../../a/b/../../a/b/../../a/b/../../a/b/../../a/b/c/d/e", nil, slices.Clone(defaultExpected)},
-			"swap-root-dotdot-extra": {".", "../outsideroot", "a/" + strings.Repeat("b/c/d/../../../", 10) + "b/c/d/e", nil, slices.Clone(defaultExpected)},
+			"swap-root-basic":        {".", "../outsideroot", "a/b/c/d/e", nil, slices_Clone(defaultExpected)},
+			"swap-root-dotdot":       {".", "../outsideroot", "a/b/../../a/b/../../a/b/../../a/b/../../a/b/../../a/b/../../a/b/../../a/b/c/d/e", nil, slices_Clone(defaultExpected)},
+			"swap-root-dotdot-extra": {".", "../outsideroot", "a/" + strings.Repeat("b/c/d/../../../", 10) + "b/c/d/e", nil, slices_Clone(defaultExpected)},
 			// Swap one of our walking paths outside the root.
 			"swap-dir-outsideroot-basic": {"a/b", "../outsideroot", "a/b/c/d/e", nil, append(
 				// We could hit the expected path.
-				slices.Clone(defaultExpected),
+				slices_Clone(defaultExpected),
 				// We could also land in the "outsideroot" path. This is okay
 				// because there was a moment when this directory was inside
 				// the root, and the attacker moved it outside the root. If we
@@ -514,7 +513,7 @@ func TestPartialLookup_RacingRename(t *testing.T) {
 			)},
 			"swap-dir-outsideroot-dotdot": {"a/b", "../outsideroot", "a/b/../../a/b/../../a/b/../../a/b/../../a/b/../../a/b/../../a/b/../../a/b/c/d/e", nil, append(
 				// We could hit the expected path.
-				slices.Clone(defaultExpected),
+				slices_Clone(defaultExpected),
 				// We could also land in the "outsideroot" path. This is okay
 				// because there was a moment when this directory was inside
 				// the root, and the attacker moved it outside the root.

--- a/openat2_linux.go
+++ b/openat2_linux.go
@@ -12,12 +12,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"golang.org/x/sys/unix"
 )
 
-var hasOpenat2 = sync.OnceValue(func() bool {
+var hasOpenat2 = sync_OnceValue(func() bool {
 	fd, err := unix.Openat2(unix.AT_FDCWD, ".", &unix.OpenHow{
 		Flags:   unix.O_PATH | unix.O_CLOEXEC,
 		Resolve: unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_IN_ROOT,

--- a/testing_mocks_linux_test.go
+++ b/testing_mocks_linux_test.go
@@ -8,7 +8,6 @@ package securejoin
 
 import (
 	"os"
-	"testing"
 )
 
 type forceGetProcRootLevel int
@@ -33,17 +32,17 @@ func testingCheckClose(check bool, f *os.File) bool {
 }
 
 func testingForcePrivateProcRootOpenTree(f *os.File) bool {
-	return testing.Testing() && testingForceGetProcRoot != nil &&
+	return testingForceGetProcRoot != nil &&
 		testingCheckClose(*testingForceGetProcRoot >= forceGetProcRootOpenTree, f)
 }
 
 func testingForcePrivateProcRootOpenTreeAtRecursive(f *os.File) bool {
-	return testing.Testing() && testingForceGetProcRoot != nil &&
+	return testingForceGetProcRoot != nil &&
 		testingCheckClose(*testingForceGetProcRoot >= forceGetProcRootOpenTreeAtRecursive, f)
 }
 
 func testingForceGetProcRootUnsafe() bool {
-	return testing.Testing() && testingForceGetProcRoot != nil &&
+	return testingForceGetProcRoot != nil &&
 		*testingForceGetProcRoot >= forceGetProcRootUnsafe
 }
 
@@ -58,12 +57,12 @@ const (
 var testingForceProcThreadSelf *forceProcThreadSelfLevel
 
 func testingForceProcSelfTask() bool {
-	return testing.Testing() && testingForceProcThreadSelf != nil &&
+	return testingForceProcThreadSelf != nil &&
 		*testingForceProcThreadSelf >= forceProcSelfTask
 }
 
 func testingForceProcSelf() bool {
-	return testing.Testing() && testingForceProcThreadSelf != nil &&
+	return testingForceProcThreadSelf != nil &&
 		*testingForceProcThreadSelf >= forceProcSelf
 }
 


### PR DESCRIPTION
We make heavy use of generics, so we can't really go earlier than Go
1.18, but we can backport some of the stdlib helpers from later Go
versions to keep the minimum Go version lower.

While such old Go versions are no longer maintained, some downstreams
want to use the new API on very old release branches where updating the
Go version is impractical. So let's make their lives easier.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>