### PR TITLE
join: loosen cleanliness requirements for SecureJoin root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
 
+### Fixed ###
+- The restrictions added for `root` paths passed to `SecureJoin` in 0.4.0 was
+  found to be too strict and caused some regressions when folks tried to
+  update, so this restriction has been relaxed to only return an error if the
+  path contains a `..` component. We still recommend users use `filepath.Clean`
+  (and even `filepath.EvalSymlinks`) on the `root` path they are using, but at
+  least you will no longer be punished for "trivial" unclean paths.
+
 ## [0.4.0] - 2025-01-13 ##
 
 ### Breaking ####

--- a/join_windows_test.go
+++ b/join_windows_test.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2017-2025 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package securejoin
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Windows has very specific behaviour relating to volumes, and we can only
+// test it on Windows machines because filepath.* behaviour depends on GOOS.
+//
+// See <https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats>
+// for more information about the various path formats we need to make sure are
+// correctly handled.
+func TestHasDotDot_WindowsVolumes(t *testing.T) {
+	for _, test := range []struct {
+		testName, path string
+		expected       bool
+	}{
+		{"plain-dotdot", `C:..`, true},            // apparently legal
+		{"relative-dotdot", `C:..\foo\bar`, true}, // apparently legal
+		{"trailing-dotdot", `D:\foo\bar\..`, true},
+		{"leading-dotdot", `F:\..\foo\bar`, true},
+		{"middle-dotdot", `F:\foo\..\bar`, true},
+		{"drive-like-path", `\foo\C:..\bar`, false}, // C:.. is a filename here
+		{"unc-dotdot", `\\gondor\share\call\for\aid\..\help`, true},
+		{"dos-dotpath-dotdot1", `\\.\C:\..\foo\bar`, true},
+		{"dos-dotpath-dotdot2", `\\.\C:\foo\..\bar`, true},
+		{"dos-questionpath-dotdot1", `\\?\C:\..\foo\bar`, true},
+		{"dos-questionpath-dotdot2", `\\?\C:\foo\..\bar`, true},
+	} {
+		test := test // copy iterator
+		t.Run(test.testName, func(t *testing.T) {
+			got := hasDotDot(test.path)
+			assert.Equalf(t, test.expected, got, "unexpected result for hasDotDot(`%s`) (VolumeName: %q)", test.path, filepath.VolumeName(test.path))
+		})
+	}
+}


### PR DESCRIPTION
It turns out that some users do provide unclean paths like "foo/bar/"
and as a result the new behaviour in commit https://github.com/cyphar/filepath-securejoin/commit/bc750ad62e1e91382c72e623ced46099258aa887 ("join: return
an error if root is unclean path") was far too aggressive and lead to
regressions.

The more gentle solution is to only error out if the path contains a
".." component (which is the only component type we are really worried
about here because it's the only one that can turn a safe
root-joined-path into an unsafe one due to how symlinks are resolved on
Linux).

Fixes: bc750ad62e1e ("join: return an error if root is unclean path")
Fixes #46
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>