### PR TITLE
proc: add ProcPid helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
      magiclinks) using this API. At the moment `filepath-securejoin` does not
      support this feature (but [libpathrs][] does).
 
+   * `ProcPid` is very similar to `ProcThreadSelf`, except it lets you get
+     handles to subpaths of other processes. Unlike `ProcThreadSelf`, it is not
+     necessary to lock the goroutine to the current thread and so no
+     `ProcThreadSelfCloser` closure will be returned.
+
+     Please note that it is possible for you to be unable to access processes
+     in certain configurations (when using `fsopen(2)`, the internal procfs
+     mount will have `subset=pids,hidepids=traceable` mount options applied,
+     which will hide many other processes and any non-process-related top-level
+     files), but `ProcPid(os.Getpid(), ...)` (to access the current
+     thread-group leader) should always work.
+
+     Also note that if the target process dies, the handle you received from
+     `ProcPid` may start returning errors or blank data when you operate on it.
+
    * `ProcSelfFdReadlink` lets you get the in-kernel path representation of a
      file descriptor (think `readlink("/proc/self/fd/...")`). This is
      equivalent to doing a `readlinkat(fd, "", ...)` of

--- a/procfs_linux.go
+++ b/procfs_linux.go
@@ -216,12 +216,6 @@ var errUnsafeProcfs = errors.New("unsafe procfs detected")
 // [os.File]: https://pkg.go.dev/os#File
 type ProcThreadSelfCloser func()
 
-// NOTE: THIS IS NOT YET SAFE TO EXPORT. The non-openat2(2) case is just using
-// a plain openat(2), which is not entirely safe against overmount attacks.
-// Yes, if we are using fsopen(2) or open_tree(2) (without AT_RECURSIVE), then
-// this is safe, but we shouldn't make less privileged users (or users on older
-// kernels) incorrectly assume this is safe. libpathrs does it correctly, and
-// it's best to leave it to them.
 func procThreadSelf(procRoot *os.File, subpath string) (_ *os.File, _ ProcThreadSelfCloser, Err error) {
 	// If called from the external API, procRoot will be nil, so just get the
 	// global root handle. It's also possible one of our tests calls this with

--- a/procfs_linux_test.go
+++ b/procfs_linux_test.go
@@ -252,6 +252,13 @@ func TestProcOvermountSubdir_ProcThreadSelf(t *testing.T) {
 	})
 }
 
+// isFsopenRoot returns whether the internal procfs handle is an fsopen root.
+func isFsopenRoot(t *testing.T) bool {
+	procRoot, err := getProcRoot()
+	require.NoError(t, err)
+	return procRoot.Name() == "fsmount:fscontext:proc"
+}
+
 // Because of the introduction of protections against /proc overmounts,
 // ProcThreadSelf will not be called in actual tests unless we have a basic
 // test here.
@@ -267,7 +274,11 @@ func TestProcThreadSelf(t *testing.T) {
 
 			realPath, err := ProcSelfFdReadlink(handle)
 			require.NoError(t, err)
-			wantPath := fmt.Sprintf("/proc/%d/task/%d/stat", os.Getpid(), unix.Gettid())
+			wantPath := fmt.Sprintf("/%d/task/%d/stat", os.Getpid(), unix.Gettid())
+			if !isFsopenRoot(t) {
+				// The /proc prefix is only present when not using fsopen.
+				wantPath = "/proc" + wantPath
+			}
 			assert.Equal(t, wantPath, realPath, "final handle path")
 		})
 
@@ -281,7 +292,11 @@ func TestProcThreadSelf(t *testing.T) {
 
 			realPath, err := ProcSelfFdReadlink(handle)
 			require.NoError(t, err)
-			wantPath := fmt.Sprintf("/proc/%d/task/%d/stat", os.Getpid(), unix.Gettid())
+			wantPath := fmt.Sprintf("/%d/task/%d/stat", os.Getpid(), unix.Gettid())
+			if !isFsopenRoot(t) {
+				// The /proc prefix is only present when not using fsopen.
+				wantPath = "/proc" + wantPath
+			}
 			assert.Equal(t, wantPath, realPath, "final handle path")
 		})
 
@@ -295,7 +310,11 @@ func TestProcThreadSelf(t *testing.T) {
 
 			realPath, err := ProcSelfFdReadlink(handle)
 			require.NoError(t, err)
-			wantPath := fmt.Sprintf("/proc/%d/task/%d/stat", os.Getpid(), unix.Gettid())
+			wantPath := fmt.Sprintf("/%d/task/%d/stat", os.Getpid(), unix.Gettid())
+			if !isFsopenRoot(t) {
+				// The /proc prefix is only present when not using fsopen.
+				wantPath = "/proc" + wantPath
+			}
 			assert.Equal(t, wantPath, realPath, "final handle path")
 		})
 
@@ -311,6 +330,67 @@ func TestProcThreadSelf(t *testing.T) {
 			require.Error(t, err, "ProcThreadSelf(/../...)")
 			require.Nil(t, handle, "ProcThreadSelf(/../...) handle")
 			require.Nil(t, closer, "ProcThreadSelf(/../...) closer")
+		})
+	})
+}
+
+func TestProcPid(t *testing.T) {
+	withWithoutOpenat2(t, true, func(t *testing.T) {
+		t.Run("pid1-stat", func(t *testing.T) {
+			handle, err := ProcPid(1, "stat")
+			require.NoError(t, err, "ProcPid(1, stat)")
+			require.NotNil(t, handle, "ProcPid(1, stat) handle")
+
+			realPath, err := ProcSelfFdReadlink(handle)
+			require.NoError(t, err)
+			wantPath := "/1/stat"
+			if !isFsopenRoot(t) {
+				// The /proc prefix is only present when not using fsopen.
+				wantPath = "/proc" + wantPath
+			}
+			assert.Equal(t, wantPath, realPath, "final handle path")
+		})
+
+		t.Run("pid1-stat-abspath", func(t *testing.T) {
+			handle, err := ProcPid(1, "/stat")
+			require.NoError(t, err, "ProcPid(1, /stat)")
+			require.NotNil(t, handle, "ProcPid(1, /stat) handle")
+
+			realPath, err := ProcSelfFdReadlink(handle)
+			require.NoError(t, err)
+			wantPath := "/1/stat"
+			if !isFsopenRoot(t) {
+				// The /proc prefix is only present when not using fsopen.
+				wantPath = "/proc" + wantPath
+			}
+			assert.Equal(t, wantPath, realPath, "final handle path")
+		})
+
+		t.Run("pid1-stat-wacky-abspath", func(t *testing.T) {
+			handle, err := ProcPid(1, "////.////stat")
+			require.NoError(t, err, "ProcPid(1, ////.////stat)")
+			require.NotNil(t, handle, "ProcPid(1, ////.////stat) handle")
+
+			realPath, err := ProcSelfFdReadlink(handle)
+			require.NoError(t, err)
+			wantPath := "/1/stat"
+			if !isFsopenRoot(t) {
+				// The /proc prefix is only present when not using fsopen.
+				wantPath = "/proc" + wantPath
+			}
+			assert.Equal(t, wantPath, realPath, "final handle path")
+		})
+
+		t.Run("dotdot", func(t *testing.T) {
+			handle, err := ProcPid(1, "../../../../../../../../..")
+			require.Error(t, err, "ProcPid(1, ../...)")
+			require.Nil(t, handle, "ProcPid(1, ../...) handle")
+		})
+
+		t.Run("wacky-dotdot", func(t *testing.T) {
+			handle, err := ProcPid(1, "/../../../../../../../../..")
+			require.Error(t, err, "ProcPid(1, /../...)")
+			require.Nil(t, handle, "ProcPid(1, /../...) handle")
 		})
 	})
 }


### PR DESCRIPTION
This is basically a more minimal version of libpathrs's ProcRoot
support, but limited to pids (our internal proc handle has subset=pids).
libpathrs has more complicated handling to support for more cases, but
those aren't really needed in filepath-securejoin.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>