### PR TITLE
codecov: rename to .yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,4 +17,3 @@ coverage:
 
 github_checks:
   annotations: false
-


### PR DESCRIPTION
We need a dummy commit to activate CodeCov for this repo, we might as
well rename the config file to be ".yml".

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>