### PR TITLE
proc: add ProcRoot API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
      Also note that if the target process dies, the handle you received from
      `ProcPid` may start returning errors or blank data when you operate on it.
 
+   * `ProcRoot` lets you get access to top-level `/proc` paths, which is
+     primarily useful for things like sysctls.
+
+     As this requires access to non-`subset=pids` paths, the internal
+     `fsopen("procfs")` handle is not restricted and so you should use this
+     method with care. Leaking this file descriptor (even in subtle ways) can
+     easily lead to very concerning [CVE-2024-21626][]-style bugs where a
+     privileged user could break out of containers.
+
    * `ProcSelfFdReadlink` lets you get the in-kernel path representation of a
      file descriptor (think `readlink("/proc/self/fd/...")`). This is
      equivalent to doing a `readlinkat(fd, "", ...)` of
@@ -99,6 +108,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   and so it seems prudent to avoid it. This mirrors [a similar change made to
   libpathrs][libpathrs-pr204].
 
+[CVE-2024-21626]: https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv
 [libpathrs]: https://github.com/cyphar/libpathrs
 [libpathrs-pr204]: https://github.com/cyphar/libpathrs/pull/204
 [statx.2]: https://www.man7.org/linux/man-pages/man2/statx.2.html

--- a/open_linux.go
+++ b/open_linux.go
@@ -63,7 +63,7 @@ func OpenInRoot(root, unsafePath string) (*os.File, error) {
 //
 // [CVE-2019-19921]: https://github.com/advisories/GHSA-fh74-hm69-rqjw
 func Reopen(handle *os.File, flags int) (*os.File, error) {
-	procRoot, err := getProcRoot()
+	procRoot, err := getProcRootSubset() // subset=pids
 	if err != nil {
 		return nil, err
 	}

--- a/openat_linux.go
+++ b/openat_linux.go
@@ -28,7 +28,7 @@ func dupFile(f *os.File) (*os.File, error) {
 // *informational* string that describes a reasonable pathname for the given
 // *at(2) arguments. You must not use the full path for any actual filesystem
 // operations.
-func prepareAt(dir *os.File, path string) (dirFd int, unsafeFullPath string) {
+func prepareAt(dir *os.File, path string) (dirFd int, unsafeUnmaskedPath string) {
 	dirFd, dirPath := -int(unix.EBADF), "."
 	if dir != nil {
 		dirFd, dirPath = int(dir.Fd()), dir.Name()

--- a/procfs_linux.go
+++ b/procfs_linux.go
@@ -309,13 +309,13 @@ const (
 	// STATX_MNT_ID_UNIQUE is provided in golang.org/x/sys@v0.20.0, but in order to
 	// avoid bumping the requirement for a single constant we can just define it
 	// ourselves.
-	STATX_MNT_ID_UNIQUE = 0x4000 //nolint:revive // unix.* name
+	_STATX_MNT_ID_UNIQUE = 0x4000 //nolint:revive // unix.* name
 
 	// We don't care which mount ID we get. The kernel will give us the unique
 	// one if it is supported. If the kernel doesn't support
 	// STATX_MNT_ID_UNIQUE, the bit is ignored and the returned request mask
 	// will only contain STATX_MNT_ID (if supported).
-	wantStatxMntMask = STATX_MNT_ID_UNIQUE | unix.STATX_MNT_ID
+	wantStatxMntMask = _STATX_MNT_ID_UNIQUE | unix.STATX_MNT_ID
 )
 
 var hasStatxMountID = sync_OnceValue(func() bool {

--- a/procfs_linux_test.go
+++ b/procfs_linux_test.go
@@ -418,6 +418,25 @@ func TestProcPid(t *testing.T) {
 	})
 }
 
+func TestProcRoot(t *testing.T) {
+	withWithoutOpenat2(t, true, func(t *testing.T) {
+		t.Run("sysctl", func(t *testing.T) {
+			handle, err := ProcRoot("sys/kernel/version")
+			require.NoError(t, err, "ProcRoot(sys/kernel/version)")
+			require.NotNil(t, handle, "ProcPid(sys/kernel/version) handle")
+
+			realPath, err := ProcSelfFdReadlink(handle)
+			require.NoError(t, err)
+			wantPath := "/sys/kernel/version"
+			if !isFsopenRoot(t) {
+				// The /proc prefix is only present when not using fsopen.
+				wantPath = "/proc" + wantPath
+			}
+			assert.Equal(t, wantPath, realPath, "final handle path")
+		})
+	})
+}
+
 func canFsOpen() bool {
 	f, err := fsopen("tmpfs", 0)
 	if f != nil {

--- a/procfs_linux_test.go
+++ b/procfs_linux_test.go
@@ -19,6 +19,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func newPrivateProcMountSubset() (*os.File, error)   { return newPrivateProcMount(true) }
+func newPrivateProcMountUnmasked() (*os.File, error) { return newPrivateProcMount(false) }
+
 func doMount(t *testing.T, source, target, fsType string, flags uintptr) {
 	var sourcePath string
 	if source != "" {
@@ -201,13 +204,23 @@ func TestProcOvermountSubdir_unsafeHostProcRoot(t *testing.T) {
 	})
 }
 
-func TestProcOvermountSubdir_newPrivateProcMount(t *testing.T) {
+func TestProcOvermountSubdir_newPrivateProcMountSubset(t *testing.T) {
 	if !hasNewMountAPI() {
 		t.Skip("test requires fsopen/open_tree support")
 	}
 	withWithoutOpenat2(t, true, func(t *testing.T) {
 		// If we create our own procfs, the overmounts shouldn't appear.
-		testProcOvermountSubdir(t, newPrivateProcMount, false)
+		testProcOvermountSubdir(t, newPrivateProcMountSubset, false)
+	})
+}
+
+func TestProcOvermountSubdir_newPrivateProcMountUnmasked(t *testing.T) {
+	if !hasNewMountAPI() {
+		t.Skip("test requires fsopen/open_tree support")
+	}
+	withWithoutOpenat2(t, true, func(t *testing.T) {
+		// If we create our own procfs, the overmounts shouldn't appear.
+		testProcOvermountSubdir(t, newPrivateProcMountUnmasked, false)
 	})
 }
 
@@ -223,22 +236,31 @@ func TestProcOvermountSubdir_clonePrivateProcMount(t *testing.T) {
 	})
 }
 
-func TestProcOvermountSubdir_getProcRoot(t *testing.T) {
+func TestProcOvermountSubdir_getProcRootSubset(t *testing.T) {
 	withWithoutOpenat2(t, true, func(t *testing.T) {
 		// We expect to not get overmounts if we have the new mount API.
 		// FIXME: It's possible to hit overmounts if there are locked mounts
 		// and we hit the AT_RECURSIVE case...
-		testProcOvermountSubdir(t, getProcRoot, !hasNewMountAPI())
+		testProcOvermountSubdir(t, getProcRootSubset, !hasNewMountAPI())
 	})
 }
 
-func TestProcOvermountSubdir_getProcRoot_Mocked(t *testing.T) {
+func TestProcOvermountSubdir_getProcRootUnmasked(t *testing.T) {
+	withWithoutOpenat2(t, true, func(t *testing.T) {
+		// We expect to not get overmounts if we have the new mount API.
+		// FIXME: It's possible to hit overmounts if there are locked mounts
+		// and we hit the AT_RECURSIVE case...
+		testProcOvermountSubdir(t, getProcRootUnmasked, !hasNewMountAPI())
+	})
+}
+
+func TestProcOvermountSubdir_getProcRootSubset_Mocked(t *testing.T) {
 	if !hasNewMountAPI() {
 		t.Skip("test requires fsopen/open_tree support")
 	}
 	withWithoutOpenat2(t, true, func(t *testing.T) {
 		testForceGetProcRoot(t, func(t *testing.T, expectOvermounts bool) {
-			testProcOvermountSubdir(t, getProcRoot, expectOvermounts)
+			testProcOvermountSubdir(t, getProcRootSubset, expectOvermounts)
 		})
 	})
 }
@@ -255,7 +277,7 @@ func TestProcOvermountSubdir_ProcThreadSelf(t *testing.T) {
 
 // isFsopenRoot returns whether the internal procfs handle is an fsopen root.
 func isFsopenRoot(t *testing.T) bool {
-	procRoot, err := getProcRoot()
+	procRoot, err := getProcRootUnmasked()
 	require.NoError(t, err)
 	return procRoot.Name() == "fsmount:fscontext:proc"
 }
@@ -448,25 +470,32 @@ func TestProcOvermount_clonePrivateProcMount(t *testing.T) {
 	testProcOvermount(t, clonePrivateProcMount, false)
 }
 
-func TestProcOvermount_newPrivateProcMount(t *testing.T) {
+func TestProcOvermount_newPrivateProcMountSubset(t *testing.T) {
 	if !hasNewMountAPI() || !canFsOpen() {
 		t.Skip("test requires fsopen support")
 	}
-	testProcOvermount(t, newPrivateProcMount, true)
+	testProcOvermount(t, newPrivateProcMountSubset, true)
 }
 
-func TestProcOvermount_getProcRoot(t *testing.T) {
+func TestProcOvermount_newPrivateProcMountUnmasked(t *testing.T) {
+	if !hasNewMountAPI() || !canFsOpen() {
+		t.Skip("test requires fsopen support")
+	}
+	testProcOvermount(t, newPrivateProcMountUnmasked, true)
+}
+
+func TestProcOvermount_getProcRootSubset(t *testing.T) {
 	privateProcMount := canFsOpen() && !testingForcePrivateProcRootOpenTree(nil)
-	testProcOvermount(t, getProcRoot, privateProcMount)
+	testProcOvermount(t, getProcRootSubset, privateProcMount)
 }
 
-func TestProcOvermount_getProcRoot_Mocked(t *testing.T) {
+func TestProcOvermount_getProcRootSubset_Mocked(t *testing.T) {
 	if !hasNewMountAPI() {
 		t.Skip("test requires fsopen/open_tree support")
 	}
 	testForceGetProcRoot(t, func(t *testing.T, _ bool) {
 		privateProcMount := canFsOpen() && !testingForcePrivateProcRootOpenTree(nil)
-		testProcOvermount(t, getProcRoot, privateProcMount)
+		testProcOvermount(t, getProcRootSubset, privateProcMount)
 	})
 }
 


### PR DESCRIPTION
This is fairly straightforward, except we need to grab an unmasked
procfs handle when doing the lookup.

Note that (unlike libpathrs), we don't do this in the error fallback
case (which would be slightly more optimal from a security perspective)
but this should be okay.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>