### PR TITLE
deps: bump to cyphar.com/go-pathrs@v0.2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6
+          version: v2.12
 
   build:
     strategy:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cyphar/filepath-securejoin
 go 1.18
 
 require (
-	cyphar.com/go-pathrs v0.2.1
+	cyphar.com/go-pathrs v0.2.5
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-cyphar.com/go-pathrs v0.2.1 h1:9nx1vOgwVvX1mNBWDu93+vaceedpbsDqo+XuBGL40b8=
-cyphar.com/go-pathrs v0.2.1/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcGc=
+cyphar.com/go-pathrs v0.2.5 h1:SnX9FBvnoyn3lUs1dkMgZ52bAETpirNu3FTRh5HlRik=
+cyphar.com/go-pathrs v0.2.5/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcGc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pathrs-lite/open_libpathrs.go
+++ b/pathrs-lite/open_libpathrs.go
@@ -53,5 +53,5 @@ func Reopen(file *os.File, flags int) (*os.File, error) {
 	}
 	defer handle.Close() //nolint:errcheck // close failures aren't critical here
 
-	return handle.OpenFile(flags)
+	return handle.OpenFile(uint64(flags))
 }


### PR DESCRIPTION
This release included some breaking changes. While most were abstracted
by the C wrappers, the open-related operations now take uint64 which
leaked into the Go API causing the following build error:

    pathrs-lite/open_libpathrs.go:56:25: cannot use flags (variable of type int) as uint64 value in argument to handle.OpenFile

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>